### PR TITLE
[FEAT]: add WebSocket server for client join/leave handling

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,10 +4,13 @@
   "description": "Server for Echo",
   "main": "src/index.js",
   "scripts": {
-    "start" : "node src/index.js",
-    "dev" : "nodemon src/index.js"
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js"
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "ws": "^8.18.3"
+  }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,58 @@
+/**
+ * WebSocket Server for Echo
+ *
+ * - Accepts client connections
+ * - First message from client is treated as username
+ * - Broadcasts join/leave messages to all connected clients
+ * - Logs all connections and disconnections with timestamps
+ */
+
+const WebSocket = require("ws");
+
+
+const PORT = process.env.PORT || 8080;
+
+// Create WebSocket server
+const wss = new WebSocket.Server({ port: PORT });
+
+// Map to store connected clients and their usernames
+const clients = new Map();
+
+function getTimestamp() {
+  return new Date().toLocaleString();
+}
+
+
+wss.on("connection", (ws) => {
+  // first message from client as username
+  ws.once("message", (message) => {
+    const username = message.toString().trim();
+
+    // store username for this client
+    clients.set(ws, username);
+    console.log(`[${getTimestamp()}] ${username} joined`);
+
+    // Notify all connected clients
+    wss.clients.forEach((client) => {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(`${username} has joined`);
+      }
+    });
+  });
+  // client disconnection
+  ws.on("close", () => {
+    const username = clients.get(ws);
+    if (username) {
+      console.log(`[${getTimestamp()}] ${username} disconnected`);
+      // Notifying all connected clients
+      wss.clients.forEach((client) => {
+        if (client.readyState === WebSocket.OPEN) {
+          client.send(`${username} has left`);
+        }
+      });
+      clients.delete(ws);
+    }
+  });
+});
+
+console.log(`WebSocket server running on port ${PORT}`);


### PR DESCRIPTION
Issue : #26
Feat :  Initial server-side implementation for Echo using Node.js and WebSockets.
What’s implemented
	•	Created /server/server.js
	•	Set up a WebSocket server using Node.js
	•	Accepts the first message from each client as a username
	•	Broadcasts join and leave messages to all connected clients
	•	Logs all client connections and disconnections with timestamps
	•	Added clear inline documentation explaining the server logic

How to test:-
	1.	Navigate to the server directory
	2.	Run:```
node server.js
                         ```
	4.	Connect using a WebSocket client (browser console or wscat)
	5.	Send a username as the first message
	6.	Open multiple clients to observe join/leave broadcasts and timestamped logs
	
	Notes:-
	•	Timestamps are logged on the server side as required
	•	Client-side timestamp display can be added later if needed