### PR TITLE
Add real-time chat messaging support across the client and server

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -6,8 +6,9 @@ In here, after solving an issue successfully, **(IF AND ONLY IF IT IS MENTIONED 
 Format of documentation: </br>
 
 {your github id} {issue number and name}: </br>
+
 - List of all features you've implemented, any particular format regarding them etc. Screenshots are allowed and appreciated.
-- also - zero emojis. or em dashes. 
+- also - zero emojis. or em dashes.
 - Begin writing documentation from after the heading.
 
 # DOCUMENTATION
@@ -16,10 +17,25 @@ Format of documentation: </br>
 
 - Added chat.go, changed main.go to call chat.go
 - chat.go has 3 functions:
+
 ```go
 connectToEchoServer() // connects to the server, sends the username, printout the server message
 getUsername() // gets the username from the user/stdin and returns it as a string
-getTimestamp() // returns the current timestamp as a string in the format of "02/01/2006 03:04:05 PM" 
+getTimestamp() // returns the current timestamp as a string in the format of "02/01/2006 03:04:05 PM"
 ```
+
 - go.mod was updated to include the module github.com/gorilla/websocket
-- tested the code locally 
+- tested the code locally
+
+### {HarshitRSethi} {#67 Getting an Upgrade!}
+
+- Updated server/server.js so that:
+  - the first message sent by a client is treated as the username and stored for that connection
+  - every message after that is treated as a chat message
+  - each message is broadcast to all connected clients
+  - messages include a timestamp and the username of the sender
+- Updated client/chat.go so that:
+  - after sending the username once, the user can continue sending chat messages from the terminal
+  - messages received from the server are printed along with timestamps
+  - a goroutine is used to listen for incoming messages while the main thread handles user input
+- Tested locally with two clients connected to the same server to verify that messages are sent and received correctly, with usernames and timestamps shown as expected

--- a/server/server.js
+++ b/server/server.js
@@ -9,7 +9,6 @@
 
 const WebSocket = require("ws");
 
-
 const PORT = process.env.PORT || 8080;
 
 // Create WebSocket server
@@ -21,7 +20,6 @@ const clients = new Map();
 function getTimestamp() {
   return new Date().toLocaleString();
 }
-
 
 wss.on("connection", (ws) => {
   // first message from client as username
@@ -39,6 +37,24 @@ wss.on("connection", (ws) => {
       }
     });
   });
+
+  // Handle all subsequent message as chat message
+  ws.on("message", (message) => {
+    const text = message.toString().trim();
+    const username = clients.get(ws);
+    const time = getTimestamp();
+
+    // Formatting message
+    const finalMessage = `${time}: ${username} said: ${text}`;
+
+    // Broadcasting to all connected clients
+    wss.clients.forEach((client) => {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(finalMessage);
+      }
+    });
+  });
+
   // client disconnection
   ws.on("close", () => {
     const username = clients.get(ws);


### PR DESCRIPTION
Issue: #67 

FIX: Add username-based chat support
Clients now send their username first, and every message after that is broadcast to all connected clients with a timestamp. The Go client was updated so users can keep sending messages after connecting. Tested locally with two clients.

<img width="1500" height="254" alt="Screenshot 2025-12-28 at 15 26 38" src="https://github.com/user-attachments/assets/6724f889-e616-4364-81c8-66699f8c68ee" />
